### PR TITLE
Fix checkPath on edit

### DIFF
--- a/js/src/components/page-form/index.js
+++ b/js/src/components/page-form/index.js
@@ -274,12 +274,21 @@ const addPathError = (el, msg) => {
  */
 
 const checkPath = async path => {
-  const res = await axios.get(`${config.apibase}/checkpath${path.value}`)
-  if (res.data.ok) {
-    removePathError(path)
-  } else {
-    addPathError(path, res.data.error)
+  const form = closest(path, 'form')
+  const action = form ? form.getAttribute('action') : null
+  const isEdit = action && action !== '/new' && action === path.value
+  if (!isEdit) {
+    try {
+      const res = await axios.get(`${config.apibase}/checkpath${path.value}`)
+      if (!res.data.ok) {
+        addPathError(path, res.data.error)
+        return
+      }
+    } catch {
+      removePathError(path)
+    }
   }
+  removePathError(path)
 }
 
 /**


### PR DESCRIPTION
Don't check the path if the path value is the same as the form action. That means it's an edit form. Of course the path exists then, because it's a page you're editing. That doesn't mean you can't edit it.